### PR TITLE
Include a sample dev.json file with the sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ __Note:__ By default, repository mirroring is disabled. Go to `.github/workflows
 * `infra/src/index.ts` - your stack definition.
 * `infra/src/permissions.ts` - your stack with IAM permissions needed to deploy the app with CI.
 * `infra/src/buildspec.yaml` - [Build specification reference for CodeBuild].
-
+* `config/default.sample.json` - example configuration file (rename to default.json to use)
+* `config/dev.json` - local development configuration file that overrides default.json.
 
 <!-- Links -->
 [Mira accelerator]: https://github.com/nearform/mira

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,6 +1,1 @@
-{
-  "app": {
-    "prefix": "nf",
-    "name": "my-s3-webhosting-example"
-  }
-}
+{}

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,0 +1,6 @@
+{
+  "app": {
+    "prefix": "nf",
+    "name": "my-s3-webhosting-example"
+  }
+}


### PR DESCRIPTION
Mira allows us to override various configuration attributes using a dev.json file in the config directory. 

This PR includes the file and sample usage. 

This should also remove the NODE_ENV warning as per Mira issue https://github.com/nearform/mira/issues/86. 

```sh
WARNING: NODE_ENV value of 'dev' did not match any deployment config file names.
WARNING: See https://github.com/lorenwest/node-config/wiki/Strict-Mode
```

