### PR TITLE
Use mira domain command to deploy custom domain

### DIFF
--- a/infra/src/index.ts
+++ b/infra/src/index.ts
@@ -1,14 +1,32 @@
-import { MiraStack, AutoDeleteBucket } from 'mira'
+import { MiraStack, AutoDeleteBucket, CustomCertificate, CustomDomain, MiraConfig, Account } from 'mira'
 import { Construct } from '@aws-cdk/core'
 import {
   BucketDeployment,
   Source as S3DeploymentSource
 } from '@aws-cdk/aws-s3-deployment'
+import {
+  CloudFrontAllowedMethods,
+  CloudFrontWebDistribution,
+  OriginProtocolPolicy,
+  SecurityPolicyProtocol,
+  SSLMethod
+} from '@aws-cdk/aws-cloudfront'
 import * as path from 'path'
+
+interface CertificateConfigProps {
+  certificateArn: string
+  webAppUrl: string
+}
+
+interface AccountWithDomainSettings extends Account {
+  withDomain?: boolean
+  webAppUrl?: string
+}
 
 export default class S3Webhosting extends MiraStack {
   constructor (parent: Construct) {
     super(parent, S3Webhosting.name)
+    
     const bucketProps = {
       publicReadAccess: true,
       websiteIndexDocument: 'index.html',
@@ -17,12 +35,88 @@ export default class S3Webhosting extends MiraStack {
     const siteBucket = new AutoDeleteBucket(this, 'SiteBucket', bucketProps)
     this.addOutput('WebsiteURL', siteBucket.bucketWebsiteUrl)
 
-    const webAppPath = path.join(__dirname, '..', '..', 'web-app')
+    const config = MiraConfig.getEnvironment() as AccountWithDomainSettings
+
+    let distributionDomainName
+    if (config.withDomain) {
+      if (!config.webAppUrl) {
+        throw new Error('"webAppUrl" config is required when "withDomain" is true')
+      }
+      distributionDomainName = this.getFullDeployment(siteBucket, config.webAppUrl)
+    } else {
+      distributionDomainName = this.getMinimalDeployment(siteBucket)
+    }
+    this.addOutput('distributionDomainName', distributionDomainName)
+  }
+
+  private getMinimalDeployment (siteBucket: AutoDeleteBucket): string {
+    const distribution = this.getCloudFrontDistribution(siteBucket)
+    
+    this.createBucketDeployment(siteBucket, distribution)
+
+    return distribution.distributionDomainName
+  }
+
+  private getFullDeployment (siteBucket: AutoDeleteBucket, webAppUrl: string): string {
+    const certificate = new CustomCertificate(this, {
+      domain: webAppUrl
+    })
+
+    const distribution = this.getCloudFrontDistribution(siteBucket, {
+      certificateArn: certificate.certificateArn,
+      webAppUrl
+    })
+
+    new CustomDomain(this, {
+      source: webAppUrl,
+      target: distribution.distributionDomainName
+    })
+
+    return distribution.distributionDomainName
+  }
+
+  createBucketDeployment(siteBucket: AutoDeleteBucket, distribution: CloudFrontWebDistribution) {
     new BucketDeployment(this, 'Deployment', {
       destinationBucket: siteBucket,
+      distribution,
+      distributionPaths: ['/*'],
       sources: [
-        S3DeploymentSource.asset(webAppPath)
+        S3DeploymentSource.asset(path.join(__dirname, '..', '..', 'web-app'))
       ]
     })
+  }
+
+  private getCloudFrontDistribution(siteBucket: any, certificateConfig?: CertificateConfigProps) {
+    const aliasConfiguration = certificateConfig ? {
+      acmCertRef: certificateConfig.certificateArn,
+      names: [certificateConfig.webAppUrl],
+      securityPolicy: SecurityPolicyProtocol.TLS_V1_1_2016,
+      sslMethod: SSLMethod.SNI
+    } : undefined
+
+    return new CloudFrontWebDistribution(
+      this,
+      'Distribution',
+      {
+        aliasConfiguration,
+        originConfigs: [
+          {
+            behaviors: [{ isDefaultBehavior: true }],
+            customOriginSource: {
+              domainName: siteBucket.bucketWebsiteDomainName,
+              originProtocolPolicy:
+              OriginProtocolPolicy.HTTP_ONLY
+            }
+          }
+        ],
+        errorConfigurations: [
+          {
+            errorCode: 404,
+            responseCode: 200,
+            responsePagePath: '/index.html'
+          }
+        ]
+      }
+    )
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "build": "tsc -p infra/",
     "dev": "tsc -p infra/ --watch",
+    "domain:app": "mira domain --env=default",
+    "domain:domain": "mira domain --env=domain",
     "deploy": "mira deploy mira-sample-s3-webhosting --file=infra/src/index.js"
   },
   "devDependencies": {

--- a/web-app/index.html
+++ b/web-app/index.html
@@ -1,1 +1,11 @@
-Hello World!
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mira S3 Sample</title>
+</head>
+<body>
+  Hello World!
+</body>
+</html>


### PR DESCRIPTION
Adds support to deploy the sample application to a custom domain using the `mira domain` command.